### PR TITLE
Add logout button with power icon

### DIFF
--- a/components/SidebarUserInfo.tsx
+++ b/components/SidebarUserInfo.tsx
@@ -8,6 +8,7 @@ import { signOut } from 'firebase/auth'
 import { signOutUser } from '@/redux/slices/userSlice'
 import { AppDispatch, RootState } from '@/redux/store'
 import { closeLogInModal, closeSignUpModal } from '@/redux/slices/modalSlice'
+import { PowerIcon } from '@heroicons/react/24/outline'
 
 export default function SidebarUserInfo () {
 
@@ -26,24 +27,29 @@ export default function SidebarUserInfo () {
     return (
 
 
-       <div 
+       <div
          className="flex items-center justify-start space-x-2
          xl:p-3 xl:pe-6 hover:bg-gray-500 hover:bg-opacity-10
-         rounded-full transistion cursor-pointer w-fit xl:w-[240px]
-         "
-         onClick={() => handleSignOUt()}
-         >
-         <Image
+         rounded-full transistion w-fit xl:w-[240px]"
+       >
+        <Image
           src="/assets/profile-pic.png"
           width={36}
           height={36}
           alt="Profile Picture"
           className="w-9 h-9"
-         />
-          <div className="hidden xl:flex flex-col text-sm max-w-40">
-            <span className="whitespace-normal text-ellipsis overflow-hidden font-bold">{user.name}</span>
-             <span className="whitespace-normal text-ellipsis overflow-hidden text-gray-500">{user.username}</span>
-          </div>
-     </div>               
+        />
+         <div className="hidden xl:flex flex-col text-sm max-w-40">
+           <span className="whitespace-normal text-ellipsis overflow-hidden font-bold">{user.name}</span>
+            <span className="whitespace-normal text-ellipsis overflow-hidden text-gray-500">{user.username}</span>
+         </div>
+         <button
+           onClick={() => handleSignOUt()}
+           className="p-1 rounded-full transition hover:text-red-500 hover:bg-gray-200"
+           aria-label="Sign out"
+         >
+           <PowerIcon className="w-5 h-5" />
+         </button>
+       </div>
   )
 }


### PR DESCRIPTION
## Summary
- add PowerIcon import for heroicons
- add dedicated sign out button next to user info

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851cdf42b188331aa4b8c6d7e6d707b