### PR TITLE
Add floating footer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import Sidebar from '@/components/Sidebar';
 import SignUpPrompt from '@/components/SignUpPrompt';
 import Widgets from '@/components/Widgets';
 import WebsiteOnboarding from '@/components/WebsiteOnboarding';
+import Footer from '@/components/Footer';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@/redux/store';
 import { openSignUpModal } from '@/redux/slices/modalSlice';
@@ -118,6 +119,7 @@ export default function Home() {
           <PostFeed />
           <Widgets />
         </div>
+        <Footer />
       </PreventDefaultWrapper>
       <CommentModal />
       <SignUpPrompt />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,70 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "@/redux/store";
+import Link from "next/link";
+
+export default function Footer() {
+  const user = useSelector((state: RootState) => state.user);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!user.username) return;
+    const sidebar = document.getElementById("sidebar-root");
+    const widgets = document.getElementById("widgets-root");
+
+    function getThreshold() {
+      const sidebarBottom = sidebar ? sidebar.offsetTop + sidebar.offsetHeight : 0;
+      const widgetsBottom = widgets ? widgets.offsetTop + widgets.offsetHeight : 0;
+      return Math.max(sidebarBottom, widgetsBottom) + 20;
+    }
+
+    function handleScroll() {
+      const threshold = getThreshold();
+      const bottom = window.scrollY + window.innerHeight;
+      if (bottom >= threshold) {
+        setVisible(true);
+      } else {
+        setVisible(false);
+      }
+    }
+    handleScroll();
+    window.addEventListener("scroll", handleScroll);
+    window.addEventListener("resize", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleScroll);
+    };
+  }, [user.username]);
+
+  if (!user.username) return null;
+
+  return (
+    <footer
+      className={`${
+        visible ? "fixed" : "hidden"
+      } bottom-0 left-0 right-0 bg-white bg-opacity-90 backdrop-blur-sm border-t border-gray-200 z-50`}
+    >
+      <div className="max-w-2xl mx-auto py-3 px-5 text-xs sm:text-sm flex flex-col sm:flex-row items-center justify-between space-y-2 sm:space-y-0">
+        <div className="flex space-x-4 text-[#C0BAB5] font-medium">
+          <Link href="https://www.buymeacoffee.com/sensebook" target="_blank">BuyMeACoffee</Link>
+          <Link href="https://discord.com" target="_blank">Discord</Link>
+          <Link href="https://twitter.com" target="_blank">X</Link>
+        </div>
+        <div className="text-gray-600 text-center">
+          © 2025 Sensebook. All Rights Reserved.
+          <br className="sm:hidden" />
+          Designed and Developed by {" "}
+          <Link
+            href="https://www.linkedin.com/in/nareshmandla"
+            target="_blank"
+            className="hover:underline text-[#C0BAB5]"
+          >
+            Naresh Mandla
+          </Link>{" "}
+          🌿🧠❤️
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -20,7 +20,7 @@ export default function Sidebar() {
   };
 
   return (
-    <nav className="hidden sm:flex flex-col p-3 xl:ml-20 xl:mr-10 w-[280px]">
+    <nav id="sidebar-root" className="hidden sm:flex flex-col p-3 xl:ml-20 xl:mr-10 w-[280px]">
       <div className="relative flex flex-col items-start">
         {/* Header Row: Logo + Sensebook Button */}
         <div className="flex items-center space-x-3 py-3 w-full">

--- a/components/Widgets.tsx
+++ b/components/Widgets.tsx
@@ -39,7 +39,7 @@ export default function Widgets() {
   }
 
   return (
-    <div className={`p-3 hidden lg:flex flex-col space-y-4 ps-10`} style={{ width: cardWidth }}>
+    <div id="widgets-root" className={`p-3 hidden lg:flex flex-col space-y-4 ps-10`} style={{ width: cardWidth }}>
       <div className="bg-[#EFF3F4] rounded-xl p-4">
         <h1 className="text-xl font-bold mb-4">What's Trending</h1>
         {error ? (


### PR DESCRIPTION
## Summary
- implement floating footer that only appears for logged-in users
- mount footer after Sidebar and Widgets in page layout
- assign `sidebar-root` and `widgets-root` IDs for dynamic positioning

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: cannot fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68521d8dc39c8331953d5e087a8bea52