### PR TITLE
Add Pomodoro timer and theme toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,3 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  @apply bg-white text-[#0F1419] transition-colors duration-300;
+}
+
+html.dark body {
+  @apply bg-gray-900 text-gray-100;
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import StoreProvider from "@/redux/StoreProvider";
+import Script from "next/script";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -18,7 +19,12 @@ export default function RootLayout({
   return (
     <StoreProvider>
       <html lang="en">
-       <body className={inter.className}>{children}</body>
+       <body className={`${inter.className} transition-colors duration-300`}>
+         {children}
+         <Script id="theme-init" strategy="beforeInteractive">
+           {`(function(){try{var t=localStorage.getItem('theme');if(t==='dark'){document.documentElement.classList.add('dark');}}catch(e){}})();`}
+         </Script>
+       </body>
       </html>
     </StoreProvider>
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,6 +7,50 @@ import { RootState } from "@/redux/store";
 export default function Footer() {
   const user = useSelector((state: RootState) => state.user);
   const [visible, setVisible] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(1500); // 25 minutes
+  const [overlay, setOverlay] = useState(false);
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  // initialize theme from localStorage
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem("theme");
+      if (stored === "dark") {
+        setTheme("dark");
+        document.documentElement.classList.add("dark");
+      }
+    } catch (e) {}
+  }, []);
+
+  // start 25 minute timer when user logs in
+  useEffect(() => {
+    if (!user.username) return;
+    const interval = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          setOverlay(true);
+          window.scrollTo({ top: 0, behavior: "smooth" });
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [user.username]);
+
+  const toggleTheme = () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    try {
+      localStorage.setItem("theme", newTheme);
+    } catch (e) {}
+    if (newTheme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  };
 
   useEffect(() => {
     if (!user.username) return;
@@ -24,32 +68,54 @@ export default function Footer() {
     return () => window.removeEventListener("scroll", handleScroll);
   }, [user.username, visible]);
 
-  if (!user.username || !visible) {
+  if (!user.username) {
     return null;
   }
 
+  const minutes = String(Math.floor(timeLeft / 60)).padStart(2, '0');
+  const seconds = String(timeLeft % 60).padStart(2, '0');
+
   return (
-    <footer className="fixed bottom-0 left-0 w-full bg-[#C0BAB5] bg-opacity-90 text-white px-4 py-3 flex flex-col items-center space-y-2 z-50">
-      <div className="flex space-x-4 text-sm">
-        <Link href="https://www.buymeacoffee.com/nareshmandla" target="_blank" rel="noopener noreferrer" className="hover:underline">
-          BuyMeACoffee
-        </Link>
-        <Link href="https://twitter.com/nareshmandla" target="_blank" rel="noopener noreferrer" className="hover:underline">
-          Twitter
-        </Link>
-        <Link href="https://www.linkedin.com/in/nareshmandla" target="_blank" rel="noopener noreferrer" className="hover:underline">
-          LinkedIn
-        </Link>
-      </div>
-      <p className="text-xs text-center">
-        © 2025 Sensebook. All Rights Reserved.
-        <br />
-        Designed and Developed by{' '}
-        <Link href="https://www.linkedin.com/in/nareshmandla" target="_blank" rel="noopener noreferrer" className="underline">
-          Naresh Mandla
-        </Link>{' '}
-        🌿🧠❤️
-      </p>
-    </footer>
+    <>
+      {overlay && (
+        <div className="fixed top-5 inset-x-0 flex justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-4 rounded-md shadow-lg max-w-md text-center">
+            You achieved a flow-state of being sensible. That’s good for today. Please come back later and continue your journey of becoming more sensible.
+          </div>
+        </div>
+      )}
+      {visible && (
+        <footer className="fixed bottom-0 left-0 w-full bg-[#C0BAB5] bg-opacity-90 text-white px-4 py-3 flex flex-col items-center space-y-2 z-50">
+          <div className="flex items-center justify-between w-full max-w-xs">
+            <span className="text-sm font-mono">
+              {minutes}:{seconds}
+            </span>
+            <button onClick={toggleTheme} aria-label="Toggle theme" className="text-xl">
+              {theme === 'light' ? '🌞' : '🌚'}
+            </button>
+          </div>
+          <div className="flex space-x-4 text-sm">
+            <Link href="https://www.buymeacoffee.com/nareshmandla" target="_blank" rel="noopener noreferrer" className="hover:underline">
+              BuyMeACoffee
+            </Link>
+            <Link href="https://twitter.com/nareshmandla" target="_blank" rel="noopener noreferrer" className="hover:underline">
+              Twitter
+            </Link>
+            <Link href="https://www.linkedin.com/in/nareshmandla" target="_blank" rel="noopener noreferrer" className="hover:underline">
+              LinkedIn
+            </Link>
+          </div>
+          <p className="text-xs text-center">
+            © 2025 Sensebook. All Rights Reserved.
+            <br />
+            Designed and Developed by{' '}
+            <Link href="https://www.linkedin.com/in/nareshmandla" target="_blank" rel="noopener noreferrer" className="underline">
+              Naresh Mandla
+            </Link>{' '}
+            🌿🧠❤️
+          </p>
+        </footer>
+      )}
+    </>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
- add 25 minute countdown and dark/light toggle to Footer
- enable dark mode in Tailwind
- persist theme with initialization script in layout
- style dark mode basics

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npm run build` *(fails: unable to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68522e7e6654833187fe5ec8d910ed08