### PR TITLE
Add caption with fade-in animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -18,4 +18,20 @@
   .animate-pulse-sense {
     animation: pulse-sense 2.4s ease-in-out infinite;
   }
+
+  /* Fade-in animation for caption */
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .animate-fade-in {
+    animation: fade-in 1.2s ease-out forwards;
+  }
 }

--- a/components/LoadingScreen.tsx
+++ b/components/LoadingScreen.tsx
@@ -24,9 +24,14 @@ export default function LoadingScreen() {
           alt="sense book Logo"
           className='mb-5'
         />
-        <h1 className='text-6xl font-bold mb-10'>
-          Sensebook <span className='text-[#dae1e1]'></span>
+        <h1 className='text-6xl font-bold mb-4'>
+          Sensebook
         </h1>
+
+        {/* 👇 Caption with fade-in animation */}
+        <p className="text-gray-600 text-center text-base opacity-0 animate-fade-in mt-2 max-w-sm [animation-delay:.5s]">
+          Where emotions meet expression.
+        </p>
          {/*<LinearProgress
           sx={{
             width: 265,


### PR DESCRIPTION
## Summary
- update loading screen to include caption beneath title
- define fade-in animation utility in Tailwind

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68771f8e9fb083318527d2d7a163f6cf